### PR TITLE
Expose tm1_git_py utilities as installable CLI tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,14 @@ dependencies = [
     "pyodbc>=5.2.0,<6.0.0"
 ]
 
+[project.scripts]
+tm1_to_model = "tm1_git_py.tm1_to_model:main"
+deserializer = "tm1_git_py.deserializer:main"
+serializer = "tm1_git_py.serializer:main"
+tm1project_to_filter = "tm1_git_py.tm1project_to_filter:main"
+filter = "tm1_git_py.filter:main"
+comparator = "tm1_git_py.comparator:main"
+
 [project.optional-dependencies]
 airflow= [
     "airflow_provider_tm1>=0.3.0,<1.0.0",
@@ -37,4 +45,4 @@ dev = [
 ]
 
 [tool.setuptools]
-packages = ["TM1_bedrock_py"]
+packages = ["TM1_bedrock_py", "tm1_git_py", "tm1_git_py.model"]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     name="tm1_bedrock_py",
     version=read_version(),
     description="A python modul for TM1 Bedrock.",
-    packages=["TM1_bedrock_py"],
+    packages=["TM1_bedrock_py", "tm1_git_py", "tm1_git_py.model"],
     author="",
     author_email="",
     url="",
@@ -40,6 +40,16 @@ setup(
             "pytest>=8.3.4,<9.0.0",
             "build>=1.2.2.post1,<2.0.0",
             "matplotlib>=3.10.1,<4.0.0"
+        ]
+    },
+    entry_points={
+        "console_scripts": [
+            "tm1_to_model=tm1_git_py.tm1_to_model:main",
+            "deserializer=tm1_git_py.deserializer:main",
+            "serializer=tm1_git_py.serializer:main",
+            "tm1project_to_filter=tm1_git_py.tm1project_to_filter:main",
+            "filter=tm1_git_py.filter:main",
+            "comparator=tm1_git_py.comparator:main",
         ]
     },
     python_requires=">=3.7"

--- a/tm1_git_py/__init__.py
+++ b/tm1_git_py/__init__.py
@@ -1,0 +1,2 @@
+"""CLI utilities for TM1 model processing."""
+

--- a/tm1_git_py/changeset.py
+++ b/tm1_git_py/changeset.py
@@ -3,15 +3,15 @@ from typing import List, Dict, Any, TypeVar, Optional
 
 from requests import Response
 
-from model.cube import Cube, create_cube, update_cube, delete_cube
-from model.dimension import Dimension, create_dimension, update_dimension, delete_dimension
-from model.hierarchy import Hierarchy, create_hierarchy, update_hierarchy, delete_hierarchy
-from model.subset import Subset, create_subset, update_subset, delete_subset
-from model.process import Process, create_process, update_process, delete_process
-from model.chore import Chore, create_chore, update_chore, delete_chore
+from .model.cube import Cube, create_cube, update_cube, delete_cube
+from .model.dimension import Dimension, create_dimension, update_dimension, delete_dimension
+from .model.hierarchy import Hierarchy, create_hierarchy, update_hierarchy, delete_hierarchy
+from .model.subset import Subset, create_subset, update_subset, delete_subset
+from .model.process import Process, create_process, update_process, delete_process
+from .model.chore import Chore, create_chore, update_chore, delete_chore
 from TM1py import TM1Service
 
-from tm1_git_py.model.model import Model
+from .model.model import Model
 
 T = TypeVar('T', Cube, Dimension, Process, Chore)
 
@@ -180,6 +180,7 @@ def delete_object(tm1_service: TM1Service, object_instance: T) -> Response:
 
     else:
         raise ValueError
+
 
 
 def update_object(tm1_service: TM1Service, object_instance: Dict[T, Any]) -> Response:

--- a/tm1_git_py/deserializer.py
+++ b/tm1_git_py/deserializer.py
@@ -1,22 +1,27 @@
+#!/usr/bin/env python3
 import json
 import os
-from typing import Dict, List
-from TM1py import TM1Service
-from TM1py.Utils import format_url
-
-from model.chore import Chore
-from model.cube import Cube
-from model.dimension import Dimension
-from model.element import Element
-from model.hierarchy import Hierarchy
-from model.mdxview import MDXView
-from model.model import Model
-from model.subset import Subset
-from model.process import Process
-import TM1py
 import re
+from typing import Dict, List
 
-from model.ti import TI
+from .model.chore import Chore
+from .model.cube import Cube
+from .model.dimension import Dimension
+from .model.element import Element
+from .model.hierarchy import Hierarchy
+from .model.mdxview import MDXView
+from .model.model import Model
+from .model.subset import Subset
+from .model.process import Process
+from .model.ti import TI
+
+
+def _save_pickle(model: Model, errors: Dict[str, str], output_path: str) -> None:
+    """Helper to persist the model and errors to a pickle file."""
+    import pickle
+
+    with open(output_path, "wb") as fh:
+        pickle.dump({"model": model, "errors": errors}, fh)
 
 
 def deserialize_model(dir) -> Model:
@@ -351,3 +356,25 @@ def directory_to_dict(path):
             # If the item is a file, set it to None or any specific value if needed
             directory_dict[item] = None
     return directory_dict
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Deserialize a TM1 model directory into a pickle file"
+        )
+    parser.add_argument("source", help="Directory containing the exported TM1 model")
+    parser.add_argument("output", help="Path where the pickled model will be stored")
+    args = parser.parse_args()
+
+    model, errors = deserialize_model(args.source)
+    _save_pickle(model, errors, args.output)
+    if errors:
+        print("Deserialization completed with errors. See pickle for details.")
+    else:
+        print("Deserialization completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tm1_git_py/model/__init__.py
+++ b/tm1_git_py/model/__init__.py
@@ -1,0 +1,2 @@
+"""Data classes describing TM1 objects."""
+

--- a/tm1_git_py/model/cube.py
+++ b/tm1_git_py/model/cube.py
@@ -7,11 +7,11 @@ from TM1py import TM1Service, Cube
 from requests import Response
 from TM1_bedrock_py.bedrock import data_copy_intercube
 
-from model.dimension import Dimension
-from model.element import Element
-from model.hierarchy import Hierarchy
-from model.mdxview import MDXView
-from model.subset import Subset
+from .dimension import Dimension
+from .element import Element
+from .hierarchy import Hierarchy
+from .mdxview import MDXView
+from .subset import Subset
 from TM1py.Utils import format_url
 
 

--- a/tm1_git_py/model/dimension.py
+++ b/tm1_git_py/model/dimension.py
@@ -5,9 +5,9 @@ import TM1py
 from TM1py import TM1Service, Dimension
 from requests import Response
 
-from model.element import Element
-from model.hierarchy import Hierarchy, create_hierarchy, update_hierarchy
-from model.subset import Subset
+from .element import Element
+from .hierarchy import Hierarchy, create_hierarchy, update_hierarchy
+from .subset import Subset
 from TM1py.Utils import format_url
 
 

--- a/tm1_git_py/model/hierarchy.py
+++ b/tm1_git_py/model/hierarchy.py
@@ -3,9 +3,9 @@ import re
 from typing import List, Any, Dict
 
 import TM1py
-from model.edge import Edge
-from model.element import Element, create_element, update_element, delete_element
-from model.subset import Subset, create_subset, update_subset, delete_subset
+from .edge import Edge
+from .element import Element, create_element, update_element, delete_element
+from .subset import Subset, create_subset, update_subset, delete_subset
 from TM1py.Utils import format_url
 from TM1py import TM1Service, Hierarchy
 from requests import Response

--- a/tm1_git_py/model/model.py
+++ b/tm1_git_py/model/model.py
@@ -1,10 +1,10 @@
 import json
 from typing import List
 
-from model.chore import Chore
-from model.cube import Cube
-from model.dimension import Dimension
-from model.process import Process
+from .chore import Chore
+from .cube import Cube
+from .dimension import Dimension
+from .process import Process
 from itertools import chain
 
 

--- a/tm1_git_py/model/process.py
+++ b/tm1_git_py/model/process.py
@@ -7,7 +7,7 @@ from requests import Response
 
 # Importáljuk a TI osztályt a típus-ellenőrzéshez (type hinting)
 if TYPE_CHECKING:
-    from model.ti import TI 
+    from .ti import TI
 # {
 #   "@type":"Process",
 # 	"Name":"airflow_test_success",

--- a/tm1_git_py/serializer.py
+++ b/tm1_git_py/serializer.py
@@ -1,21 +1,27 @@
+#!/usr/bin/env python3
 import json
 import os
-from typing import Dict, List
-from TM1py import TM1Service
-from TM1py.Utils import format_url
+from typing import List
 
-from model.chore import Chore
-from model.cube import Cube
-from model.dimension import Dimension
-from model.element import Element
-from model.hierarchy import Hierarchy
-from model.mdxview import MDXView
-from model.model import Model
-from model.subset import Subset
-from model.process import Process
-import TM1py
+from .model.chore import Chore
+from .model.cube import Cube
+from .model.dimension import Dimension
+from .model.element import Element
+from .model.hierarchy import Hierarchy
+from .model.mdxview import MDXView
+from .model.model import Model
+from .model.subset import Subset
+from .model.process import Process
+from .model.ti import TI
 
-from model.ti import TI
+
+def _load_pickle(input_path: str) -> Model:
+    """Load a model from a pickle file created by deserializer or tm1_to_model."""
+    import pickle
+
+    with open(input_path, "rb") as fh:
+        data = pickle.load(fh)
+    return data.get("model") if isinstance(data, dict) else data
 
 
 def serialize_model(model: Model, dir):
@@ -91,3 +97,22 @@ def serialize_chores(chores: List[Chore], chores_dir):
     for chore in chores:
         with open(chores_dir + '/' + chore.name + '.json', 'w', encoding='utf-8') as chore_file:
             chore_file.write(chore.as_json())
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Serialize a model pickle into a TM1 directory structure"
+    )
+    parser.add_argument("model", help="Path to the pickled model")
+    parser.add_argument("output", help="Directory where the model will be serialized")
+    args = parser.parse_args()
+
+    model = _load_pickle(args.model)
+    serialize_model(model, args.output)
+    print("Serialization completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tm1_git_py/tm1project_to_filter.py
+++ b/tm1_git_py/tm1project_to_filter.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import json
 import re
 
@@ -45,8 +46,19 @@ def convert_json_to_filter_txt(json_path: str, output_path: str):
     except IOError:
         print(f"'{output_path}'")
 
-# if __name__ == "__main__":
-#     input_json_file = 'tm1project.json'
-#     output_filter_file = 'tm1project_filter.txt'
-    
-#     convert_json_to_filter_txt(input_json_file, output_filter_file)
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Convert TM1 project JSON to filter text rules"
+    )
+    parser.add_argument("json", help="Input tm1project.json path")
+    parser.add_argument("output", help="Output filter.txt path")
+    args = parser.parse_args()
+
+    convert_json_to_filter_txt(args.json, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add console script entry points for TM1 model utilities
- package `tm1_git_py` so commands like `tm1_to_model` and `deserializer` run anywhere
- switch module imports to package-relative paths

## Testing
- `python -m pip install -e . --no-deps`
- `tm1_to_model --help`
- `deserializer --help`
- `serializer --help`
- `filter --help`
- `comparator --help`
- `tm1project_to_filter --help`
- `pytest` *(fails: ModuleNotFoundError: No module named 'matplotlib'; ModuleNotFoundError: No module named 'airflow')*

------
https://chatgpt.com/codex/tasks/task_e_68af1ea459b48329b5e22fd419e513b0